### PR TITLE
Add step in readme to enable ipv4 forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ $ sudo update-rc.d hostapd enable
 $ sudo update-rc.d dnsmasq enable
 ```
 
+You will need to edit `/etc/sysctl.conf` and change the `net.ipv4.ip_forward` line to:
+```
+net.ipv4.ip_forward=1
+```
+
 Optional, setup OpenVPN
 
 ```


### PR DESCRIPTION
I found that this was necessary for my PIFI to forward the connection from wlan0 to wlan1. I used this site as a resource to figure that out.

http://www.elinux.org/RPI-Wireless-Hotspot